### PR TITLE
Workaround for #28 and fix for #27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ script:
 - ./gradlew shadowJar
 after_success:
 - bash <(curl -s https://codecov.io/bash)
+after_failure:
+- find build/reports/tests -type f -exec cat {} \;
 before_deploy:
 - export RELEASE_PKG_FILE=$(ls build/libs/burp-pac-*-all.jar)
 - echo "deploying ${RELEASE_PKG_FILE} to GitHub releases"

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ jacocoTestReport {
 }
 
 check.dependsOn jacocoTestReport
+shadowJar.dependsOn check
 
 // In this section you declare where to find the dependencies of your project
 repositories {

--- a/src/main/java/us/coastalhacking/burp/pac/DefaultProxySearchProvider.java
+++ b/src/main/java/us/coastalhacking/burp/pac/DefaultProxySearchProvider.java
@@ -16,11 +16,17 @@ package us.coastalhacking.burp.pac;
 
 import com.github.markusbernhardt.proxy.ProxySearch;
 import com.github.markusbernhardt.proxy.ProxySearch.Strategy;
+import com.github.markusbernhardt.proxy.util.PlatformUtil;
+import com.github.markusbernhardt.proxy.util.PlatformUtil.Platform;
+import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 public class DefaultProxySearchProvider implements Provider<ProxySearch> {
 
   protected ProxySearch proxySearch;
+  
+  @Inject
+  protected PlatformUtil platformUtil;
 
   @Override
   public ProxySearch get() {
@@ -31,6 +37,10 @@ public class DefaultProxySearchProvider implements Provider<ProxySearch> {
       proxySearch.addStrategy(Strategy.JAVA);
       proxySearch.addStrategy(Strategy.OS_DEFAULT);
       proxySearch.addStrategy(Strategy.ENV_VAR);
+      Platform platform = PlatformUtil.getCurrentPlattform();
+      if (platform == Platform.WIN) {
+        proxySearch.addStrategy(Strategy.IE);
+      }
     }
     return proxySearch;
   }

--- a/src/test/java/us/coastalhacking/burp/pac/ProxySearchProviderTest.java
+++ b/src/test/java/us/coastalhacking/burp/pac/ProxySearchProviderTest.java
@@ -1,0 +1,28 @@
+package us.coastalhacking.burp.pac;
+
+import static org.junit.Assert.*;
+
+import com.github.markusbernhardt.proxy.ProxySearch;
+import com.github.markusbernhardt.proxy.search.browser.ie.IEProxySearchStrategy;
+import com.github.markusbernhardt.proxy.search.desktop.DesktopProxySearchStrategy;
+import com.github.markusbernhardt.proxy.search.env.EnvProxySearchStrategy;
+import com.github.markusbernhardt.proxy.search.java.JavaProxySearchStrategy;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import org.junit.Test;
+
+public class ProxySearchProviderTest {
+
+  @Test
+  public void shouldContainExpectedStrategies() {
+    Injector injector =
+        TestUtils.createInjector();
+    Provider<ProxySearch> proxySearchProvider = injector.getProvider(ProxySearch.class);
+    ProxySearch proxySearch = proxySearchProvider.get();
+    assertTrue(proxySearch.toString().contains(IEProxySearchStrategy.class.getName()));
+    assertTrue(proxySearch.toString().contains(EnvProxySearchStrategy.class.getName()));
+    assertTrue(proxySearch.toString().contains(JavaProxySearchStrategy.class.getName()));
+    assertTrue(proxySearch.toString().contains(DesktopProxySearchStrategy.class.getName()));
+  }
+  
+}

--- a/src/test/java/us/coastalhacking/burp/pac/ProxySearchProviderTest.java
+++ b/src/test/java/us/coastalhacking/burp/pac/ProxySearchProviderTest.java
@@ -7,6 +7,8 @@ import com.github.markusbernhardt.proxy.search.browser.ie.IEProxySearchStrategy;
 import com.github.markusbernhardt.proxy.search.desktop.DesktopProxySearchStrategy;
 import com.github.markusbernhardt.proxy.search.env.EnvProxySearchStrategy;
 import com.github.markusbernhardt.proxy.search.java.JavaProxySearchStrategy;
+import com.github.markusbernhardt.proxy.util.PlatformUtil;
+import com.github.markusbernhardt.proxy.util.PlatformUtil.Platform;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
 import org.junit.Test;
@@ -19,7 +21,10 @@ public class ProxySearchProviderTest {
         TestUtils.createInjector();
     Provider<ProxySearch> proxySearchProvider = injector.getProvider(ProxySearch.class);
     ProxySearch proxySearch = proxySearchProvider.get();
-    assertTrue(proxySearch.toString().contains(IEProxySearchStrategy.class.getName()));
+    // won't run on travis
+    if (PlatformUtil.getCurrentPlattform() == Platform.WIN) {
+      assertTrue(proxySearch.toString().contains(IEProxySearchStrategy.class.getName()));
+    }
     assertTrue(proxySearch.toString().contains(EnvProxySearchStrategy.class.getName()));
     assertTrue(proxySearch.toString().contains(JavaProxySearchStrategy.class.getName()));
     assertTrue(proxySearch.toString().contains(DesktopProxySearchStrategy.class.getName()));


### PR DESCRIPTION
Add IE strategy at runtime based on platform
Make `shadowJar` task depend on `test`

Closes #27 
Closes #28