### PR TITLE
PR Portswigger/proxy-auto-config develop

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,0 +1,4 @@
+<p>This extension automatically configures Burp upstream proxies to match desktop proxy settings. This includes support for Proxy Auto-Config (PAC) scripts.</p>
+
+<p>It uses Proxy Vole to detect the proxy settings. PAC scripts are executed within a sandbox.</p>
+

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,0 +1,12 @@
+Uuid: 7b3eae07aa724196ab85a8b64cd095d1
+ExtensionType: 1
+Name: Proxy Auto Config
+RepoName: proxy-auto-config
+ScreenVersion: 0.0.3
+SerialVersion: 1
+MinPlatformVersion: 0
+ProOnly: False
+Author: Jon Passki
+ShortDescription: Automatically configures Burp upstream proxies to match desktop proxy settings.
+EntryPoint: build/libs/burp-pac-0.0.3-all.jar
+BuildCommand: ./gradlew shadowJar


### PR DESCRIPTION
Hoping to make @pajswigger's life easier. Note: `develop` points to the next version: 0.0.3. `master` tracks the release version.